### PR TITLE
Add platform.sh servers to known hosts file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,12 @@ RUN apt-get install --no-install-recommends -y git ssh-client
 RUN mkdir -p ~/.ssh && \
     chmod 700 ~/.ssh && \
     ssh-keyscan git.us.platform.sh >> ~/.ssh/known_hosts && \
+    ssh-keyscan git.us-2.platform.sh >> ~/.ssh/known_hosts && \
+    ssh-keyscan git.eu.platform.sh >> ~/.ssh/known_hosts && \
+    ssh-keyscan git.eu-2.platform.sh >> ~/.ssh/known_hosts && \
+    ssh-keyscan git.eu-3.platform.sh >> ~/.ssh/known_hosts && \
+    ssh-keyscan git.eu-4.platform.sh >> ~/.ssh/known_hosts && \
+    ssh-keyscan git.au.platform.sh >> ~/.ssh/known_hosts && \
     chmod 644 ~/.ssh/known_hosts
 
 # Install the Platform.sh CLI

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,12 @@ RUN apt-get update
 # Install Git and SSH CLI clients.
 RUN apt-get install --no-install-recommends -y git ssh-client
 
+# Add platform.sh git repository server as a known host.
+RUN mkdir -p ~/.ssh && \
+    chmod 700 ~/.ssh && \
+    ssh-keyscan git.us.platform.sh >> ~/.ssh/known_hosts && \
+    chmod 644 ~/.ssh/known_hosts
+
 # Install the Platform.sh CLI
 ADD install-cli.sh .
 RUN bash ./install-cli.sh


### PR DESCRIPTION
We're using this Docker image in a CI pipeline for deployment. One of the things needed to be able to deploy from the container is that the ssh client should "know" the platform.sh git servers (or ignore host checking). I think this is a generic use case which is valid for most users of this Docker image.

This PR scans the fingerprint of `git.us.platform.sh` (git repository of the platform.sh server) and adds it to the `known_hosts` file. This helps commands like `platform push` which calls `git push` (and `ssh`).